### PR TITLE
Integrating Apps metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,25 +3,47 @@
 version = 3
 
 [[package]]
-name = "ahash"
-version = "0.8.3"
+name = "addr2line"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "getrandom",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.1"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -34,44 +56,59 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.70"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "async-trait"
-version = "0.1.68"
+version = "0.1.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
+name = "backtrace"
+version = "0.3.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "base64"
-version = "0.13.1"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "block-buffer"
@@ -84,21 +121,24 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.1"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -108,87 +148,77 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-integer",
  "num-traits",
  "serde",
- "time 0.1.45",
  "wasm-bindgen",
- "winapi",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
-name = "codespan-reporting"
-version = "0.11.1"
+name = "core-foundation"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
- "termcolor",
- "unicode-width",
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.4"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.7"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.8"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
 dependencies = [
- "cfg-if",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
 dependencies = [
- "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.14"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "autocfg",
- "cfg-if",
  "crossbeam-utils",
- "memoffset",
- "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.15"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
-dependencies = [
- "cfg-if",
-]
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crypto-common"
@@ -207,54 +237,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
-name = "cxx"
-version = "1.0.94"
+name = "deranged"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn 2.0.15",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.15",
+ "powerfmt",
 ]
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -288,18 +283,24 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.32"
+version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "fnv"
@@ -309,56 +310,56 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-core",
  "futures-macro",
@@ -381,20 +382,26 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
-name = "h2"
-version = "0.3.18"
+name = "gimli"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
+checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
+
+[[package]]
+name = "h2"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",
@@ -411,18 +418,17 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "headers"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
+checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
 dependencies = [
- "base64 0.13.1",
- "bitflags",
+ "base64",
  "bytes",
  "headers-core",
  "http",
@@ -442,18 +448,15 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "http"
-version = "0.2.9"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
@@ -462,9 +465,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
  "http",
@@ -473,15 +476,15 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
@@ -501,9 +504,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.26"
+version = "0.14.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
+checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -525,10 +528,11 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.2"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
+ "futures-util",
  "http",
  "hyper",
  "rustls",
@@ -538,33 +542,32 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.56"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows",
+ "windows-core",
 ]
 
 [[package]]
 name = "iana-time-zone-haiku"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
- "cxx",
- "cxx-build",
+ "cc",
 ]
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -572,61 +575,52 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
- "autocfg",
+ "equivalent",
  "hashbrown",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.7.2"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
+checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.142"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
-
-[[package]]
-name = "link-cplusplus"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
-dependencies = [
- "cc",
-]
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -634,12 +628,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "matchers"
@@ -647,29 +638,20 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
-name = "memoffset"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
-dependencies = [
- "autocfg",
-]
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mimalloc-rust"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6973866e0bc6504c03a16b6817b7e70839cc8a1dbd5d6dab00c65d8034868d8b"
+checksum = "5eb726c8298efb4010b2c46d8050e4be36cf807b9d9e98cb112f830914fc9bbe"
 dependencies = [
  "cty",
  "mimalloc-rust-sys",
@@ -677,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc-rust-sys"
-version = "1.7.6-source"
+version = "1.7.9-source"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a50daf45336b979a202a19f53b4b382f2c4bd50f392a8dbdb4c6c56ba5dfa64"
+checksum = "6413e13241a9809f291568133eca6694572cf528c1a6175502d090adce5dd5db"
 dependencies = [
  "cc",
  "cty",
@@ -692,15 +674,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "mio"
-version = "0.8.6"
+name = "miniz_oxide"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+dependencies = [
+ "hermit-abi",
  "libc",
- "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.45.0",
+ "wasi",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -723,39 +725,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.45"
+name = "num-conv"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.15.0"
+name = "object"
+version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
 dependencies = [
- "hermit-abi",
- "libc",
+ "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "overload"
@@ -765,9 +762,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -775,28 +772,28 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys 0.45.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -806,9 +803,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "poem"
-version = "1.3.55"
+version = "1.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0608069d4999c3c02d49dff261663f2e73a8f7b00b7cd364fb5e93e419dafa1"
+checksum = "504774c97b0744c1ee108a37e5a65a9745a4725c4c06277521dabc28eb53a904"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -818,6 +815,7 @@ dependencies = [
  "http",
  "hyper",
  "mime",
+ "nix",
  "parking_lot",
  "percent-encoding",
  "pin-project-lite",
@@ -834,44 +832,51 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tracing",
+ "wildmatch",
 ]
 
 [[package]]
 name = "poem-derive"
-version = "1.3.55"
+version = "1.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b839bad877aa933dd00901abd127a44496130e3def48e079d60e43f2c8a33cc"
+checksum = "42ddcf4680d8d867e1e375116203846acb088483fa2070244f90589f458bbb31"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "1.3.1"
+name = "powerfmt"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "proc-macro-crate"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24"
 dependencies = [
- "once_cell",
+ "toml_datetime",
  "toml_edit",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prometheus"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
 dependencies = [
  "cfg-if",
  "fnv",
@@ -890,18 +895,18 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.7.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -909,34 +914,33 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.11.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "num_cpus",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.8.1"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.1",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -949,6 +953,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.4",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,17 +971,17 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.1"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqwest"
-version = "0.11.16"
+version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
- "base64 0.21.0",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -988,6 +1003,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1001,72 +1018,82 @@ dependencies = [
 
 [[package]]
 name = "rfc7239"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "087317b3cf7eb481f13bd9025d729324b7cd068d6f470e2d76d049e191f5ba47"
+checksum = "b106a85eeb5b0336d16d6a20eab857f92861d4fbb1eb9a239866fb98fb6a1063"
 dependencies = [
  "uncased",
 ]
 
 [[package]]
 name = "ring"
-version = "0.16.20"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
+ "cfg-if",
+ "getrandom",
  "libc",
- "once_cell",
  "spin",
  "untrusted",
- "web-sys",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
-name = "rustls"
-version = "0.20.8"
+name = "rustc-demangle"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring",
+ "rustls-webpki",
  "sct",
- "webpki",
 ]
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64 0.21.0",
+ "base64",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "scratch"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sct"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
  "untrusted",
@@ -1074,31 +1101,32 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -1117,9 +1145,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.21"
+version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9d684e3ec7de3bf5466b32bd75303ac16f0736426e5a4e0d6e489559ce1249c"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
  "indexmap",
  "itoa",
@@ -1130,9 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1141,58 +1169,64 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.4"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.1"
+name = "shlex"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "slab"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.4.9"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "spin"
-version = "0.5.2"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1200,15 +1234,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "2.0.15"
+name = "sync_wrapper"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sysinfo"
@@ -1226,39 +1255,51 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.2.0"
+name = "system-configuration"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
- "winapi-util",
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1266,22 +1307,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.45"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
-version = "0.3.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
-dependencies = [
+ "deranged",
  "itoa",
+ "num-conv",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -1289,24 +1322,25 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.8"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 
 [[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1319,70 +1353,67 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c786bf8134e5a3a166db9b29ab8f48134739014a3eca7bc6bfa95d673b136f"
+checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
 dependencies = [
- "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.4"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls",
  "tokio",
- "webpki",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.7"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
  "tokio",
- "tracing",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.8"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -1391,17 +1422,16 @@ dependencies = [
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1409,31 +1439,32 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
 dependencies = [
  "crossbeam-channel",
- "time 0.3.20",
+ "thiserror",
+ "time",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.23"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.30"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1441,12 +1472,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
- "lazy_static",
  "log",
+ "once_cell",
  "tracing-core",
 ]
 
@@ -1462,9 +1493,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -1483,69 +1514,63 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "uncased"
-version = "0.9.7"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b01702b0fd0b3fadcf98e098780badda8742d4f4a7676615cad90e8ac73622"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
 dependencies = [
  "version_check",
 ]
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.22"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
 name = "unsafe-libyaml"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1560,25 +1585,18 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
- "log",
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -1588,34 +1606,35 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.34"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
+checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1625,9 +1644,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1635,51 +1654,44 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "webpki"
-version = "0.22.0"
+name = "webpki-roots"
+version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
-]
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
-name = "webpki-roots"
-version = "0.22.6"
+name = "wildmatch"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
-dependencies = [
- "webpki",
-]
+checksum = "3928939971918220fed093266b809d1ee4ec6c1a2d72692ff6876898f3b16c19"
 
 [[package]]
 name = "winapi"
@@ -1698,36 +1710,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.48.0"
+name = "windows-core"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.48.0",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1736,137 +1730,174 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.4.1"
+version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "winreg"
-version = "0.10.1"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "winapi",
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/Readme.md
+++ b/Readme.md
@@ -117,6 +117,19 @@ for possible fields and interpretation of numbers.
 Labels returned by Digital Ocean: droxporter_droplet_status{status} and droxporter_droplet_filesystem{device, fstype,
 mountpoint}
 
+# List of app metrics
+
+| Metric Name                            | Description                                  | Labels                                                                                                                                                                                                                                                                                                                                | Type    |
+| -------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| droxporter_app_active_deployment_phase | Last phase for current active deployment     | app - the app's name,<br /> app_component - name of the app's component (e.g. `web`),<br /> app_component_instance - numbered process (e.g. `web-0`),<br />phase - `ACTIVE` for active deployments, see [Monitoring API docs](https://docs.digitalocean.com/reference/api/api-reference/#operation/apps_list) for all possible values | Gauge   |
+| droxporter_app_cpu_percentage          | CPU % for app instance                       | app - the app's name,<br /> app_component - name of the app's component (e.g. `web`),<br /> app_component_instance - numbered process (e.g. `web-0`)                                                                                                                                                                                  | Gauge   |
+| droxporter_app_memory_percentage       | Memory % for app instance disk volume        | app - the app's name,<br /> app_component - name of the app's component (e.g. `web`),<br /> app_component_instance - numbered process (e.g. `web-0`)                                                                                                                                                                                  | Gauge   |
+| droxporter_app_restart_count           | Number of app instance restarts (as counter) | app - the app's name,<br /> app_component - name of the app's component (e.g. `web`),<br /> app_component_instance - numbered process (e.g. `web-0`)                                                                                                                                                                                  | Counter |
+
+Note: Metric values are taken directly
+from [requests](https://docs.digitalocean.com/reference/api/api-reference/#tag/Monitoring). Refer to the original source
+for possible fields and interpretation of numbers.
+
 # List of exporter's own metrics
 
 | Metric Name                                        | Description                                                                    | Labels                                                                                               | Type      |

--- a/Readme.md
+++ b/Readme.md
@@ -6,6 +6,7 @@ The main features of Droxporter include:
 
 * Lightweight and efficient. Written entirely in Rust.
 * Collecting Droplet-related metrics, such as CPU usage, memory usage, disk space, bandwidth, and more.
+* Collecting AppPlatform-related metrics, such as CPU usage and memory usage.
 * Support for HTTPS, basic authentication, and custom settings.
 * Built-in rate limiting to respect DigitalOcean's API rate limits and avoid potential issues. 
 * Ability to use multiple API keys for better flexibility and control over the rate limits.
@@ -17,8 +18,8 @@ Digital Ocean provides an [API](https://docs.digitalocean.com/reference/api/api-
 HTTP methods
 for [retrieving a list of droplets](https://docs.digitalocean.com/reference/api/api-reference/#operation/droplets_list)
 and
-for [metrics](https://docs.digitalocean.com/reference/api/api-reference/#tag/Monitoring) on droplets.
-The exporter periodically polls Digital Ocean for the list of droplets and caches it.
+for [metrics on apps and droplets](https://docs.digitalocean.com/reference/api/api-reference/#tag/Monitoring).
+The exporter periodically polls Digital Ocean for the list of droplets and apps and caches it.
 The exporter also launches periodic tasks to poll Digital Ocean for metrics on these droplets and store their metrics.
 Although Digital Ocean provides an interval of points in the response, only the last one is saved, as there are no
 timestamps in the Prometheus endpoint.
@@ -35,8 +36,9 @@ so it is highly recommended to review the [Limits And Keys](#limits-and-keys) se
 ## Primary use case
 
 The droxporter exporter is best suited for personal or small projects when there's no time to set up
-[node_exporter](https://github.com/prometheus/node_exporter) on all machines. You can install a simple exporter on a
-single node and not worry for some time. To understand our limitations, see the next section.
+[node_exporter](https://github.com/prometheus/node_exporter) on all machines or if you are interested in metrics
+on apps. You can install a simple exporter on a single node and not worry for some time. To understand our limitations,
+see the next section.
 
 ## Limitations
 

--- a/config.yml
+++ b/config.yml
@@ -54,7 +54,6 @@ apps:
   keys: [ ]
   url: "https://api.digitalocean.com/v2/apps"
   interval: 1h # default 1h
-  # No support for app specific metrics yet
   metrics: # default []
     - active_deployment_phase
 

--- a/config.yml
+++ b/config.yml
@@ -55,7 +55,8 @@ apps:
   url: "https://api.digitalocean.com/v2/apps"
   interval: 1h # default 1h
   # No support for app specific metrics yet
-  metrics: [ ] # default []
+  metrics: # default []
+    - active_deployment_phase
 
 # List of metrics to be loaded
 # A separate request will be executed for each type within 'types' for each droplet, so be careful
@@ -89,3 +90,18 @@ droplet-metrics: # default {}
     keys: [ ] # default []
     interval: 120s # default 120s
     enabled: false # default false
+
+app-metrics: # default {}
+  base-url: "https://api.digitalocean.com/v2/monitoring/metrics/apps"
+  cpu-percentage: # default {}
+    keys: [ ] # default []
+    interval: 60s
+    enabled: true
+  memory-percentage: # default {}
+    keys: [ ] # default []
+    interval: 60s
+    enabled: true
+  restart-count: # default {}
+    keys: [ ] # default []
+    interval: 60s
+    enabled: true

--- a/config.yml
+++ b/config.yml
@@ -49,13 +49,21 @@ droplets: # default {}
     - disk
     - status
 
+# App Platform polling.
+apps:
+  keys: [ ]
+  url: "https://api.digitalocean.com/v2/apps"
+  interval: 1h # default 1h
+  # No support for app specific metrics yet
+  metrics: [ ] # default []
+
 # List of metrics to be loaded
 # A separate request will be executed for each type within 'types' for each droplet, so be careful
 # not to add too many to avoid hitting request limits
 # The intervals are wide because:
 ##  1. To avoid hitting limits
 ##  2. Data on Digital Ocean updates infrequently
-metrics: # default {}
+droplet-metrics: # default {}
   base-url: "https://api.digitalocean.com/v2/monitoring/metrics/droplet"
   bandwidth: # default {}
     types: [ private_inbound, private_outbound, public_inbound, public_outbound ] # default []
@@ -81,8 +89,3 @@ metrics: # default {}
     keys: [ ] # default []
     interval: 120s # default 120s
     enabled: false # default false
-
-
-
-
-

--- a/src/client/do_client.rs
+++ b/src/client/do_client.rs
@@ -378,8 +378,8 @@ impl DigitalOceanClient for DigitalOceanClientImpl {
     }
 
     async fn list_apps(&self,
-                           per_page: u64,
-                           page: u64) -> anyhow::Result<ListAppsResponse> {
+                       per_page: u64,
+                       page: u64) -> anyhow::Result<ListAppsResponse> {
         let mut url = Url::parse(self.config.apps.url.as_str())?;
         url.query_pairs_mut()
             .append_pair("per_page", per_page.to_string().as_str())

--- a/src/client/do_client.rs
+++ b/src/client/do_client.rs
@@ -5,10 +5,12 @@ use chrono::Utc;
 use prometheus::{HistogramOpts, Opts, Registry};
 use reqwest::StatusCode;
 use url::Url;
-use crate::client::do_json_protocol::{DataResponse, ListDropletsResponse, ListAppsResponse};
+use crate::client::do_json_protocol::{DropletDataResponse, ListDropletsResponse, ListAppsResponse};
 use crate::client::key_manager::{KeyManager, KeyType};
 use crate::config::config_model::{AgentMetricsType, AppSettings};
 use crate::metrics::utils::DROXPORTER_DEFAULT_BUCKETS;
+
+use super::do_json_protocol::AppDataResponse;
 
 #[async_trait]
 pub trait DigitalOceanClient: Send + Sync {
@@ -22,39 +24,57 @@ pub trait DigitalOceanClient: Send + Sync {
                        page: u64) -> anyhow::Result<ListAppsResponse>;
 
 
-    async fn get_bandwidth(&self,
-                           host_id: u64,
-                           interface: NetworkInterface,
-                           direction: NetworkDirection,
-                           start: chrono::DateTime<Utc>,
-                           end: chrono::DateTime<Utc>) -> anyhow::Result<DataResponse>;
+    async fn get_droplet_bandwidth(&self,
+                                   host_id: u64,
+                                   interface: NetworkInterface,
+                                   direction: NetworkDirection,
+                                   start: chrono::DateTime<Utc>,
+                                   end: chrono::DateTime<Utc>) -> anyhow::Result<DropletDataResponse>;
 
 
-    async fn get_cpu(&self,
-                     host_id: u64,
-                     start: chrono::DateTime<Utc>,
-                     end: chrono::DateTime<Utc>) -> anyhow::Result<DataResponse>;
+    async fn get_droplet_cpu(&self,
+                             host_id: u64,
+                             start: chrono::DateTime<Utc>,
+                             end: chrono::DateTime<Utc>) -> anyhow::Result<DropletDataResponse>;
 
 
-    async fn get_file_system(&self,
+    async fn get_droplet_file_system(&self,
                              host_id: u64,
                              metric_type: FileSystemRequest,
                              start: chrono::DateTime<Utc>,
-                             end: chrono::DateTime<Utc>) -> anyhow::Result<DataResponse>;
+                             end: chrono::DateTime<Utc>) -> anyhow::Result<DropletDataResponse>;
 
 
     async fn get_droplet_memory(&self,
                                 host_id: u64,
                                 metric_type: MemoryRequest,
                                 start: chrono::DateTime<Utc>,
-                                end: chrono::DateTime<Utc>) -> anyhow::Result<DataResponse>;
+                                end: chrono::DateTime<Utc>) -> anyhow::Result<DropletDataResponse>;
 
 
-    async fn get_load(&self,
-                      host_id: u64,
-                      load_type: ClientLoadType,
-                      start: chrono::DateTime<Utc>,
-                      end: chrono::DateTime<Utc>) -> anyhow::Result<DataResponse>;
+    async fn get_droplet_load(&self,
+                              host_id: u64,
+                              load_type: ClientLoadType,
+                              start: chrono::DateTime<Utc>,
+                              end: chrono::DateTime<Utc>) -> anyhow::Result<DropletDataResponse>;
+
+
+    async fn get_app_cpu_percentage(&self,
+                                    app_id: String,
+                                    start: chrono::DateTime<Utc>,
+                                    end: chrono::DateTime<Utc>) -> anyhow::Result<AppDataResponse>;
+
+
+    async fn get_app_memory_percentage(&self,
+                                       app_id: String,
+                                       start: chrono::DateTime<Utc>,
+                                       end: chrono::DateTime<Utc>) -> anyhow::Result<AppDataResponse>;
+
+
+    async fn get_app_restart_count(&self,
+                                   app_id: String,
+                                   start: chrono::DateTime<Utc>,
+                                   end: chrono::DateTime<Utc>) -> anyhow::Result<AppDataResponse>;
 }
 
 
@@ -158,11 +178,11 @@ impl DigitalOceanClientMetrics {
 
 
 impl DigitalOceanClientImpl {
-    async fn base_metrics_request(&self,
-                                  request_type: RequestType,
-                                  host_id: u64,
-                                  start: chrono::DateTime<Utc>,
-                                  end: chrono::DateTime<Utc>) -> anyhow::Result<DataResponse> {
+    async fn base_droplet_metrics_request(&self,
+                                          request_type: RequestType,
+                                          host_id: u64,
+                                          start: chrono::DateTime<Utc>,
+                                          end: chrono::DateTime<Utc>) -> anyhow::Result<DropletDataResponse> {
         let suffix = request_type.to_request_suffix()?;
         let mut url = {
             let base = self.config.droplet_metrics.base_url.as_str();
@@ -194,7 +214,48 @@ impl DigitalOceanClientImpl {
             return Err(anyhow::Error::msg(err));
         }
 
-        let res = response.json::<DataResponse>().await?;
+        let res = response.json::<DropletDataResponse>().await?;
+
+
+        Ok(res)
+    }
+
+    async fn base_app_metrics_request(&self,
+                                      request_type: RequestType,
+                                      app_id: String,
+                                      start: chrono::DateTime<Utc>,
+                                      end: chrono::DateTime<Utc>) -> anyhow::Result<AppDataResponse> {
+        let suffix = request_type.to_request_suffix()?;
+        let mut url = {
+            let base = self.config.app_metrics.base_url.as_str();
+            let str = format!("{base}/{suffix}"); // or path_segments_mut?
+            Url::parse(str.as_str())?
+        };
+
+        url.query_pairs_mut()
+            .append_pair("app_id", app_id.as_str())
+            .append_pair("start", start.timestamp().to_string().as_str())
+            .append_pair("end", end.timestamp().to_string().as_str());
+
+        let bearer = self.token_manager.acquire_key(request_type.into())?;
+        let time = Instant::now();
+
+        let response = self.client
+            .get(url)
+            .bearer_auth(bearer)
+            .send()
+            .await?;
+
+        self.metrics.record_client_metrics(suffix, response.status().as_str(), time);
+
+        if response.status() != StatusCode::OK && response.status() != StatusCode::NO_CONTENT {
+            let status = response.status();
+            let body = response.text().await?;
+            let err = format!("Request failed with status code: {status}, body: {body}");
+            return Err(anyhow::Error::msg(err));
+        }
+
+        let res = response.json::<AppDataResponse>().await?;
 
 
         Ok(res)
@@ -206,17 +267,20 @@ impl DigitalOceanClientImpl {
 pub enum RequestType {
     Droplets,
     Apps,
-    Bandwidth,
-    Cpu,
-    FileSystemFree,
-    FileSystemSize,
-    CachedMemory,
-    FreeMemory,
-    TotalMemory,
-    AvailableTotalMemory,
-    Load1,
-    Load5,
-    Load15,
+    DropletBandwidth,
+    DropletCpu,
+    DropletFileSystemFree,
+    DropletFileSystemSize,
+    DropletCachedMemory,
+    DropletFreeMemory,
+    DropletTotalMemory,
+    DropletAvailableTotalMemory,
+    DropletLoad1,
+    DropletLoad5,
+    DropletLoad15,
+    AppCpuPercentage,
+    AppMemoryPercentage,
+    AppRestartCount,
 }
 
 #[derive(Clone, Copy)]
@@ -237,17 +301,20 @@ pub enum MemoryRequest {
 impl RequestType {
     pub fn to_request_suffix(self) -> anyhow::Result<&'static str> {
         match self {
-            RequestType::Bandwidth => Ok("bandwidth"),
-            RequestType::Cpu => Ok("cpu"),
-            RequestType::FileSystemFree => Ok("filesystem_free"),
-            RequestType::FileSystemSize => Ok("filesystem_size"),
-            RequestType::CachedMemory => Ok("memory_cached"),
-            RequestType::FreeMemory => Ok("memory_free"),
-            RequestType::TotalMemory => Ok("memory_total"),
-            RequestType::AvailableTotalMemory => Ok("memory_available"),
-            RequestType::Load1 => Ok("load_1"),
-            RequestType::Load5 => Ok("load_5"),
-            RequestType::Load15 => Ok("load_15"),
+            RequestType::DropletBandwidth => Ok("bandwidth"),
+            RequestType::DropletCpu => Ok("cpu"),
+            RequestType::DropletFileSystemFree => Ok("filesystem_free"),
+            RequestType::DropletFileSystemSize => Ok("filesystem_size"),
+            RequestType::DropletCachedMemory => Ok("memory_cached"),
+            RequestType::DropletFreeMemory => Ok("memory_free"),
+            RequestType::DropletTotalMemory => Ok("memory_total"),
+            RequestType::DropletAvailableTotalMemory => Ok("memory_available"),
+            RequestType::DropletLoad1 => Ok("load_1"),
+            RequestType::DropletLoad5 => Ok("load_5"),
+            RequestType::DropletLoad15 => Ok("load_15"),
+            RequestType::AppCpuPercentage => Ok("cpu_percentage"),
+            RequestType::AppMemoryPercentage => Ok("memory_percentage"),
+            RequestType::AppRestartCount => Ok("restart_count"),
             _ => anyhow::bail!("Unexpected key type")
         }
     }
@@ -258,17 +325,20 @@ impl Into<KeyType> for RequestType {
         match self {
             RequestType::Droplets => KeyType::Droplets,
             RequestType::Apps => KeyType::Apps,
-            RequestType::Bandwidth => KeyType::Bandwidth,
-            RequestType::Cpu => KeyType::Cpu,
-            RequestType::FileSystemFree => KeyType::FileSystem,
-            RequestType::FileSystemSize => KeyType::FileSystem,
-            RequestType::CachedMemory => KeyType::Memory,
-            RequestType::FreeMemory => KeyType::Memory,
-            RequestType::TotalMemory => KeyType::Memory,
-            RequestType::AvailableTotalMemory => KeyType::Memory,
-            RequestType::Load1 => KeyType::Load,
-            RequestType::Load5 => KeyType::Load,
-            RequestType::Load15 => KeyType::Load,
+            RequestType::DropletBandwidth => KeyType::DropletBandwidth,
+            RequestType::DropletCpu => KeyType::DropletCpu,
+            RequestType::DropletFileSystemFree => KeyType::DropletFileSystem,
+            RequestType::DropletFileSystemSize => KeyType::DropletFileSystem,
+            RequestType::DropletCachedMemory => KeyType::DropletMemory,
+            RequestType::DropletFreeMemory => KeyType::DropletMemory,
+            RequestType::DropletTotalMemory => KeyType::DropletMemory,
+            RequestType::DropletAvailableTotalMemory => KeyType::DropletMemory,
+            RequestType::DropletLoad1 => KeyType::DropletLoad,
+            RequestType::DropletLoad5 => KeyType::DropletLoad,
+            RequestType::DropletLoad15 => KeyType::DropletLoad,
+            RequestType::AppCpuPercentage => KeyType::AppCpuPercentage,
+            RequestType::AppMemoryPercentage => KeyType::AppMemoryPercentage,
+            RequestType::AppRestartCount => KeyType::AppRestartCount,
         }
     }
 }
@@ -318,7 +388,6 @@ impl DigitalOceanClient for DigitalOceanClientImpl {
         let bearer = self.token_manager.acquire_key(RequestType::Apps.into())?;
         let time = Instant::now();
 
-        println!("URL: {}", url);
         let response = self.client
             .get(url)
             .bearer_auth(bearer)
@@ -340,12 +409,12 @@ impl DigitalOceanClient for DigitalOceanClientImpl {
         Ok(res)
     }
 
-    async fn get_bandwidth(&self,
-                           host_id: u64,
-                           interface: NetworkInterface,
-                           direction: NetworkDirection,
-                           start: chrono::DateTime<Utc>,
-                           end: chrono::DateTime<Utc>) -> anyhow::Result<DataResponse> {
+    async fn get_droplet_bandwidth(&self,
+                                   host_id: u64,
+                                   interface: NetworkInterface,
+                                   direction: NetworkDirection,
+                                   start: chrono::DateTime<Utc>,
+                                   end: chrono::DateTime<Utc>) -> anyhow::Result<DropletDataResponse> {
         let mut url = {
             let base = self.config.droplet_metrics.base_url.as_str();
             let str = format!("{base}/bandwidth"); // or path_segments_mut?
@@ -362,7 +431,7 @@ impl DigitalOceanClient for DigitalOceanClientImpl {
             .append_pair("start", start.timestamp().to_string().as_str())
             .append_pair("end", end.timestamp().to_string().as_str());
 
-        let bearer = self.token_manager.acquire_key(RequestType::Bandwidth.into())?;
+        let bearer = self.token_manager.acquire_key(RequestType::DropletBandwidth.into())?;
         let time = Instant::now();
 
         let response = self.client
@@ -380,33 +449,33 @@ impl DigitalOceanClient for DigitalOceanClientImpl {
             return Err(anyhow::Error::msg(err));
         }
 
-        let res = response.json::<DataResponse>().await?;
+        let res = response.json::<DropletDataResponse>().await?;
 
         Ok(res)
     }
 
-    async fn get_cpu(&self,
-                     host_id: u64,
-                     start: chrono::DateTime<Utc>,
-                     end: chrono::DateTime<Utc>) -> anyhow::Result<DataResponse> {
-        self.base_metrics_request(
-            RequestType::Cpu,
+    async fn get_droplet_cpu(&self,
+                             host_id: u64,
+                             start: chrono::DateTime<Utc>,
+                             end: chrono::DateTime<Utc>) -> anyhow::Result<DropletDataResponse> {
+        self.base_droplet_metrics_request(
+            RequestType::DropletCpu,
             host_id,
             start,
             end,
         ).await
     }
 
-    async fn get_file_system(&self,
-                             host_id: u64,
-                             request: FileSystemRequest,
-                             start: chrono::DateTime<Utc>,
-                             end: chrono::DateTime<Utc>) -> anyhow::Result<DataResponse> {
+    async fn get_droplet_file_system(&self,
+                                     host_id: u64,
+                                     request: FileSystemRequest,
+                                     start: chrono::DateTime<Utc>,
+                                     end: chrono::DateTime<Utc>) -> anyhow::Result<DropletDataResponse> {
         let request = match request {
-            FileSystemRequest::Free => RequestType::FileSystemFree,
-            FileSystemRequest::Size => RequestType::FileSystemSize
+            FileSystemRequest::Free => RequestType::DropletFileSystemFree,
+            FileSystemRequest::Size => RequestType::DropletFileSystemSize
         };
-        self.base_metrics_request(
+        self.base_droplet_metrics_request(
             request,
             host_id,
             start,
@@ -419,15 +488,15 @@ impl DigitalOceanClient for DigitalOceanClientImpl {
                                 host_id: u64,
                                 metric_type: MemoryRequest,
                                 start: chrono::DateTime<Utc>,
-                                end: chrono::DateTime<Utc>) -> anyhow::Result<DataResponse> {
+                                end: chrono::DateTime<Utc>) -> anyhow::Result<DropletDataResponse> {
         let request_type = match metric_type {
-            MemoryRequest::CachedMemory => RequestType::CachedMemory,
-            MemoryRequest::FreeMemory => RequestType::FreeMemory,
-            MemoryRequest::TotalMemory => RequestType::TotalMemory,
-            MemoryRequest::AvailableTotalMemory => RequestType::AvailableTotalMemory,
+            MemoryRequest::CachedMemory => RequestType::DropletCachedMemory,
+            MemoryRequest::FreeMemory => RequestType::DropletFreeMemory,
+            MemoryRequest::TotalMemory => RequestType::DropletTotalMemory,
+            MemoryRequest::AvailableTotalMemory => RequestType::DropletAvailableTotalMemory,
         };
 
-        self.base_metrics_request(
+        self.base_droplet_metrics_request(
             request_type,
             host_id,
             start,
@@ -436,20 +505,59 @@ impl DigitalOceanClient for DigitalOceanClientImpl {
     }
 
 
-    async fn get_load(&self,
-                      host_id: u64,
-                      load_type: ClientLoadType,
-                      start: chrono::DateTime<Utc>,
-                      end: chrono::DateTime<Utc>) -> anyhow::Result<DataResponse> {
+    async fn get_droplet_load(&self,
+                              host_id: u64,
+                              load_type: ClientLoadType,
+                              start: chrono::DateTime<Utc>,
+                              end: chrono::DateTime<Utc>) -> anyhow::Result<DropletDataResponse> {
         let request_type = match load_type {
-            ClientLoadType::Load1 => RequestType::Load1,
-            ClientLoadType::Load5 => RequestType::Load5,
-            ClientLoadType::Load15 => RequestType::Load15,
+            ClientLoadType::Load1 => RequestType::DropletLoad1,
+            ClientLoadType::Load5 => RequestType::DropletLoad5,
+            ClientLoadType::Load15 => RequestType::DropletLoad15,
         };
 
-        self.base_metrics_request(
+        self.base_droplet_metrics_request(
             request_type,
             host_id,
+            start,
+            end,
+        ).await
+    }
+
+
+    async fn get_app_cpu_percentage(&self,
+                                    app_id: String,
+                                    start: chrono::DateTime<Utc>,
+                                    end: chrono::DateTime<Utc>) -> anyhow::Result<AppDataResponse> {
+        self.base_app_metrics_request(
+            RequestType::AppCpuPercentage,
+            app_id,
+            start,
+            end,
+        ).await
+    }
+
+
+    async fn get_app_memory_percentage(&self,
+                                       app_id: String,
+                                       start: chrono::DateTime<Utc>,
+                                       end: chrono::DateTime<Utc>) -> anyhow::Result<AppDataResponse> {
+        self.base_app_metrics_request(
+            RequestType::AppMemoryPercentage,
+            app_id,
+            start,
+            end,
+        ).await
+    }
+
+
+    async fn get_app_restart_count(&self,
+                                   app_id: String,
+                                   start: chrono::DateTime<Utc>,
+                                   end: chrono::DateTime<Utc>) -> anyhow::Result<AppDataResponse> {
+        self.base_app_metrics_request(
+            RequestType::AppRestartCount,
+            app_id,
             start,
             end,
         ).await

--- a/src/client/do_json_protocol.rs
+++ b/src/client/do_json_protocol.rs
@@ -1,10 +1,12 @@
 use std::fmt;
-use serde::{Deserialize};
+use serde::Deserialize;
 use serde::de::{SeqAccess, Visitor};
 
 #[derive(Deserialize, PartialEq, Debug)]
 pub struct ListDropletsResponse {
     pub droplets: Vec<DropletResponse>,
+    #[serde(default)]
+    pub links: Links,
 }
 
 
@@ -23,7 +25,23 @@ pub struct DropletResponse {
 #[derive(Deserialize, PartialEq, Debug)]
 pub struct ListAppsResponse {
     #[serde(default)]
+    pub links: Links,
+    #[serde(default)]
     pub apps: Vec<AppResponse>,
+}
+
+#[derive(Deserialize, PartialEq, Debug, Default)]
+pub struct Links {
+    #[serde(default)]
+    pub pages: Pages,
+}
+
+#[derive(Deserialize, PartialEq, Debug, Default)]
+pub struct Pages {
+    pub prev: Option<String>,
+    pub next: Option<String>,
+    pub first: Option<String>,
+    pub last: Option<String>,
 }
 
 #[derive(Deserialize, PartialEq, Debug)]
@@ -156,13 +174,22 @@ fn deserialize_points<'de, D>(deserializer: D) -> Result<Vec<MetricPoint>, D::Er
 
 #[cfg(test)]
 mod deserialize_test {
-    use crate::client::do_json_protocol::{AppDataResponse, AppDataResult, AppMetricMetaInfo, AppMetricsResponse, AppResponse, AppSpec, AppActiveDeployment, DropletDataResponse, DropletDataResult, DropletMetricMetaInfo, DropletMetricsResponse, DropletResponse, ListAppsResponse, ListDropletsResponse, MetricPoint};
+    use crate::client::do_json_protocol::{AppDataResponse, AppDataResult, AppMetricMetaInfo, AppMetricsResponse, AppResponse, AppSpec, AppActiveDeployment, DropletDataResponse, DropletDataResult, DropletMetricMetaInfo, DropletMetricsResponse, DropletResponse, ListAppsResponse, ListDropletsResponse, MetricPoint, Links, Pages};
 
     #[test]
     fn deserialize_droplets() {
         let json_data = r#"{"droplets":[{"id":336239184,"name":"traefik-zitadel-1","memory":2048,"vcpus":1,"disk":50,"locked":false,"status":"active","kernel":null,"created_at":"2023-01-17T17:12:08Z","features":["monitoring","droplet_agent","private_networking"],"backup_ids":[],"next_backup_window":null,"snapshot_ids":[],"image":{"id":119383150,"name":"22.10 x64","distribution":"Ubuntu","slug":"ubuntu-22-10-x64","public":true,"regions":["nyc3","nyc1","sfo1","nyc2","ams2","sgp1","lon1","ams3","fra1","tor1","sfo2","blr1","sfo3","syd1"],"created_at":"2022-10-22T19:58:00Z","min_disk_size":7,"type":"base","size_gigabytes":0.74,"description":"Ubuntu 22.10 (LTS) x64","tags":[],"status":"available"},"volume_ids":[],"size":{"slug":"s-1vcpu-2gb","memory":2048,"vcpus":1,"disk":50,"transfer":2.0,"price_monthly":12.0,"price_hourly":0.01786,"regions":["ams3","blr1","fra1","lon1","nyc1","nyc3","sfo3","sgp1","syd1","tor1"],"available":true,"description":"Basic"},"size_slug":"s-1vcpu-2gb","networks":{"v4":[{"ip_address":"164.90.185.107","netmask":"255.255.240.0","gateway":"164.90.176.1","type":"public"},{"ip_address":"10.114.0.3","netmask":"255.255.240.0","gateway":"10.114.0.1","type":"private"}],"v6":[]},"region":{"name":"Frankfurt 1","slug":"fra1","features":["backups","ipv6","metadata","install_agent","storage","image_transfer"],"available":true,"sizes":["s-1vcpu-512mb-10gb","s-1vcpu-1gb","s-1vcpu-1gb-amd","s-1vcpu-1gb-intel","s-1vcpu-2gb","s-1vcpu-2gb-amd","s-1vcpu-2gb-intel","s-2vcpu-2gb","s-2vcpu-2gb-amd","s-2vcpu-2gb-intel","s-2vcpu-4gb","s-2vcpu-4gb-amd","s-2vcpu-4gb-intel","c-2","c2-2vcpu-4gb","s-4vcpu-8gb","s-4vcpu-8gb-amd","s-4vcpu-8gb-intel","g-2vcpu-8gb","gd-2vcpu-8gb","m-2vcpu-16gb","c-4","c2-4vcpu-8gb","s-8vcpu-16gb","m3-2vcpu-16gb","c-4-intel","s-8vcpu-16gb-amd","s-8vcpu-16gb-intel","c2-4vcpu-8gb-intel","g-4vcpu-16gb","so-2vcpu-16gb","m6-2vcpu-16gb","gd-4vcpu-16gb","so1_5-2vcpu-16gb","m-4vcpu-32gb","c-8","c2-8vcpu-16gb","m3-4vcpu-32gb","c-8-intel","c2-8vcpu-16gb-intel","g-8vcpu-32gb","so-4vcpu-32gb","m6-4vcpu-32gb","gd-8vcpu-32gb","so1_5-4vcpu-32gb","m-8vcpu-64gb","c-16","c2-16vcpu-32gb","m3-8vcpu-64gb","c-16-intel","c2-16vcpu-32gb-intel","g-16vcpu-64gb","so-8vcpu-64gb","m6-8vcpu-64gb","gd-16vcpu-64gb","so1_5-8vcpu-64gb","m-16vcpu-128gb","c-32","c2-32vcpu-64gb","m3-16vcpu-128gb","c-32-intel","c2-32vcpu-64gb-intel","m-24vcpu-192gb","g-32vcpu-128gb","so-16vcpu-128gb","m6-16vcpu-128gb","gd-32vcpu-128gb","m3-24vcpu-192gb","g-40vcpu-160gb","so1_5-16vcpu-128gb","c-48-intel","m-32vcpu-256gb","gd-40vcpu-160gb","c2-48vcpu-96gb-intel","so-24vcpu-192gb","m6-24vcpu-192gb","m3-32vcpu-256gb","so1_5-24vcpu-192gb","so-32vcpu-256gb","m6-32vcpu-256gb","so1_5-32vcpu-256gb"]},"tags":[],"vpc_uuid":"addcb62f-5973-465d-964c-4ffcac4f8b52"}],"links":{"pages":{"first":"https://api.digitalocean.com/v2/droplets?page=1\u0026per_page=1","prev":"https://api.digitalocean.com/v2/droplets?page=1\u0026per_page=1","next":"https://api.digitalocean.com/v2/droplets?page=3\u0026per_page=1","last":"https://api.digitalocean.com/v2/droplets?page=3\u0026per_page=1"}},"meta":{"total":3}}"#;
         let deserialized_data: ListDropletsResponse = serde_json::from_str(json_data).unwrap();
         let expected_result = ListDropletsResponse {
+            links: Links {
+                pages: Pages {
+                    first: Some("https://api.digitalocean.com/v2/droplets?page=1&per_page=1".to_string()),
+                    prev: Some("https://api.digitalocean.com/v2/droplets?page=1&per_page=1".to_string()),
+                    next: Some("https://api.digitalocean.com/v2/droplets?page=3&per_page=1".to_string()),
+                    last: Some("https://api.digitalocean.com/v2/droplets?page=3&per_page=1".to_string()),
+                },
+                ..Default::default()
+            },
             droplets: vec![
                 DropletResponse {
                     id: 336239184,
@@ -185,6 +212,14 @@ mod deserialize_test {
 "#;
         let deserialized_data: ListAppsResponse = serde_json::from_str(json_data).unwrap();
         let expected_result = ListAppsResponse {
+            links: Links {
+                pages: Pages {
+                    last: Some("https://api.digitalocean.com/v2/apps?page=11&per_page=1".to_string()),
+                    next: Some("https://api.digitalocean.com/v2/apps?page=2&per_page=1".to_string()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
             apps: vec![
                 AppResponse {
                     id: "3a8aa5b2-3d92-4d0d-9d38-3214f08f3a57".to_string(),
@@ -208,6 +243,14 @@ mod deserialize_test {
         let json_data = r#"{"meta":{"total":11},"links":{"pages":{"first":"https://api.digitalocean.com/v2/apps?page=1\u0026per_page=100","prev":"https://api.digitalocean.com/v2/apps?page=1\u0026per_page=100"}}}"#;
         let deserialized_data: ListAppsResponse = serde_json::from_str(json_data).unwrap();
         let expected_result = ListAppsResponse {
+            links: Links {
+                pages: Pages {
+                    first: Some("https://api.digitalocean.com/v2/apps?page=1&per_page=100".to_string()),
+                    prev: Some("https://api.digitalocean.com/v2/apps?page=1&per_page=100".to_string()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
             apps: vec![]
         };
 

--- a/src/client/do_json_protocol.rs
+++ b/src/client/do_json_protocol.rs
@@ -21,6 +21,24 @@ pub struct DropletResponse {
 
 
 #[derive(Deserialize, PartialEq, Debug)]
+pub struct ListAppsResponse {
+    #[serde(default)]
+    pub apps: Vec<AppResponse>,
+}
+
+#[derive(Deserialize, PartialEq, Debug)]
+pub struct AppResponse {
+    pub id: String,
+    pub spec: AppSpec,
+}
+
+#[derive(Deserialize, PartialEq, Debug)]
+pub struct AppSpec {
+    pub name: String,
+}
+
+
+#[derive(Deserialize, PartialEq, Debug)]
 pub struct DataResponse {
     pub status: String,
     pub data: DataResult,
@@ -98,7 +116,7 @@ fn deserialize_points<'de, D>(deserializer: D) -> Result<Vec<MetricPoint>, D::Er
 
 #[cfg(test)]
 mod deserialize_test {
-    use crate::client::do_json_protocol::{DataResponse, DataResult, DropletResponse, ListDropletsResponse, MetricMetaInfo, MetricPoint, MetricsResponse};
+    use crate::client::do_json_protocol::{AppResponse, AppSpec, DataResponse, DataResult, DropletResponse, ListAppsResponse, ListDropletsResponse, MetricMetaInfo, MetricPoint, MetricsResponse};
 
     #[test]
     fn deserialize_droplets() {
@@ -116,6 +134,36 @@ mod deserialize_test {
                     status: "active".to_string(),
                 }
             ]
+        };
+
+        assert_eq!(deserialized_data, expected_result)
+    }
+
+    #[test]
+    fn deserialize_apps() {
+        let json_data = r#"{"meta":{"total":11},"links":{"pages":{"last":"https://api.digitalocean.com/v2/apps?page=11&per_page=1","next":"https://api.digitalocean.com/v2/apps?page=2&per_page=1"}},"apps":[{"id":"3a8aa5b2-3d92-4d0d-9d38-3214f08f3a57","owner_uuid":"13a391ec-d5fb-477e-a5b6-c62369d38c15","spec":{"name":"AppName","services":[{"name":"web","image":{"registry_type":"DOCR","repository":"RepoName","tag":"web","deploy_on_push":{}},"instance_size_slug":"apps-s-1vcpu-1gb-fixed","instance_count":1,"http_port":8080}],"domains":[{"domain":"api.example.com","type":"PRIMARY"}],"region":"fra","alerts":[{"rule":"DEPLOYMENT_FAILED"},{"rule":"DOMAIN_FAILED"}],"ingress":{"rules":[{"match":{"path":{"prefix":"/"}},"component":{"name":"web"}}]},"features":["buildpack-stack=ubuntu-22"]},"last_deployment_active_at":"2024-08-30T13:58:33Z","default_ingress":"https://AppName.ondigitalocean.app","created_at":"2024-07-08T14:51:42Z","updated_at":"2024-09-19T13:36:02Z","active_deployment":{"id":"c079d423-e050-4a22-97cd-e9fbbbf020ad","spec":{"name":"AppName","services":[{"name":"web","image":{"registry_type":"DOCR","repository":"RepoName","tag":"web","deploy_on_push":{}},"instance_size_slug":"apps-s-1vcpu-1gb-fixed","instance_count":1,"http_port":8080}],"domains":[{"domain":"api.example.com","type":"PRIMARY"}],"region":"fra","alerts":[{"rule":"DEPLOYMENT_FAILED"},{"rule":"DOMAIN_FAILED"}],"ingress":{"rules":[{"match":{"path":{"prefix":"/"}},"component":{"name":"web"}}]},"features":["buildpack-stack=ubuntu-22"]},"services":[{"name":"web","source_image_digest":"sha256:c24c1c13e86d92ecb496c8050174af95fd5df76dbb866e34729055bd3a13bbb8"}],"phase_last_updated_at":"2024-08-30T13:58:33Z","created_at":"2024-08-30T13:57:54Z","updated_at":"2024-09-13T13:58:37Z","cause":"manual","progress":{"success_steps":6,"total_steps":6,"steps":[{"name":"build","status":"SUCCESS","steps":[{"name":"initialize","status":"SUCCESS","started_at":"2024-08-30T13:57:57.672434261Z","ended_at":"2024-08-30T13:57:57.759162219Z"},{"name":"components","status":"SUCCESS","steps":[{"name":"web","status":"SUCCESS","reason":{"code":"PreBuiltImage","message":"Your build job was skipped because you specified a pre-built image."},"component_name":"web","message_base":"Building service"}],"started_at":"2024-08-30T13:57:57.759197958Z","ended_at":"2024-08-30T13:57:57.759737867Z"}],"started_at":"2024-08-30T13:57:57.672359656Z","ended_at":"2024-08-30T13:57:57.759966408Z"},{"name":"deploy","status":"SUCCESS","steps":[{"name":"initialize","status":"SUCCESS","started_at":"2024-08-30T13:57:59.735041686Z","ended_at":"2024-08-30T13:58:00.763926223Z"},{"name":"components","status":"SUCCESS","steps":[{"name":"web","status":"SUCCESS","steps":[{"name":"deploy","status":"SUCCESS","component_name":"web","message_base":"Deploying service"},{"name":"wait","status":"SUCCESS","component_name":"web","message_base":"Waiting for service"}],"component_name":"web"}],"started_at":"2024-08-30T13:58:00.763948038Z","ended_at":"2024-08-30T13:58:31.844593165Z"},{"name":"finalize","status":"SUCCESS","started_at":"2024-08-30T13:58:32.364561249Z","ended_at":"2024-08-30T13:58:33.190573345Z"}],"started_at":"2024-08-30T13:57:59.735022449Z","ended_at":"2024-08-30T13:58:33.190642962Z"}]},"phase":"ACTIVE","tier_slug":"basic","previous_deployment_id":"923b6d07-70a1-45b5-9e46-f1ed0687764c","cause_details":{"digitalocean_user_action":{"user":{"uuid":"22b08b29-899a-458d-a788-d9c128165574","email":"admin@example.com","full_name":"AdminUser"},"name":"CREATE_DEPLOYMENT"},"type":"MANUAL"},"timing":{"pending":"3.672434261s","build_total":"0.087532147s","build_billable":"0s"}},"last_deployment_created_at":"2024-08-30T13:57:54Z","live_url":"https://api.example.com","region":{"slug":"fra","label":"Frankfurt","flag":"germany","continent":"Europe","data_centers":["fra1"]},"tier_slug":"basic","live_url_base":"https://api.example.com","live_domain":"api.example.com","domains":[{"id":"dd6c8d8e-2943-4526-95ce-686e0cd28b1a","spec":{"domain":"api.example.com","type":"PRIMARY"},"phase":"ACTIVE","progress":{"steps":[{"name":"default-ingress-ready","status":"SUCCESS","started_at":"2024-09-19T13:35:59.634545234Z"},{"name":"ensure-zone","status":"SUCCESS","started_at":"2024-09-19T13:35:59.634633033Z","ended_at":"2024-07-08T15:29:34.369563407Z"},{"name":"ensure-ns-records","status":"SUCCESS","started_at":"2024-09-19T13:35:59.634703204Z","ended_at":"2024-07-08T15:29:34.369629876Z"},{"name":"verify-nameservers","status":"SUCCESS","started_at":"2024-09-19T13:35:59.634817566Z","ended_at":"2024-07-08T15:29:34.369693003Z"},{"name":"ensure-record","status":"SUCCESS","started_at":"2024-09-19T13:35:59.634912842Z","ended_at":"2024-07-08T15:29:34.369758476Z"},{"name":"ensure-alias-record","status":"SUCCESS","started_at":"2024-09-19T13:35:59.634982353Z","ended_at":"2024-07-08T15:29:34.369836232Z"},{"name":"ensure-wildcard-record","status":"SUCCESS","started_at":"2024-09-19T13:35:59.635050384Z","ended_at":"2024-07-08T15:29:34.369917605Z"},{"name":"verify-cname","status":"SUCCESS","started_at":"2024-09-19T13:35:59.717673396Z"},{"name":"ensure-ssl-txt-record-saved","status":"SUCCESS","started_at":"2024-09-19T13:36:00.049765662Z","ended_at":"2024-07-08T15:29:34.699300167Z"},{"name":"ensure-ssl-txt-record","status":"SUCCESS","started_at":"2024-09-19T13:36:00.049962156Z","ended_at":"2024-07-08T15:29:34.699370946Z"},{"name":"ensure-renewal-email","status":"SUCCESS","started_at":"2024-09-19T13:36:00.050064902Z","ended_at":"2024-07-08T15:29:34.699419605Z"},{"name":"ensure-CA-authorization","status":"SUCCESS","started_at":"2024-09-19T13:36:00.050148486Z"},{"name":"ensure-certificate","status":"SUCCESS","started_at":"2024-09-19T13:36:00.196127105Z"},{"name":"create-deployment","status":"SUCCESS","ended_at":"2024-07-08T15:31:26.846132585Z"},{"name":"configuration-alert","status":"SUCCESS","started_at":"2024-09-19T13:36:00.595405647Z","ended_at":"2024-07-08T15:29:35.389412129Z"}]},"validation":{},"certificate_expires_at":"2024-12-04T13:48:56Z"}],"build_config":{}}]}
+"#;
+        let deserialized_data: ListAppsResponse = serde_json::from_str(json_data).unwrap();
+        let expected_result = ListAppsResponse {
+            apps: vec![
+                AppResponse {
+                    id: "3a8aa5b2-3d92-4d0d-9d38-3214f08f3a57".to_string(),
+                    spec: AppSpec {
+                        name: "AppName".to_string(),
+                    },
+                }
+            ]
+        };
+
+        assert_eq!(deserialized_data, expected_result)
+    }
+
+    #[test]
+    fn deserialize_apps_empty_response() {
+        let json_data = r#"{"meta":{"total":11},"links":{"pages":{"first":"https://api.digitalocean.com/v2/apps?page=1\u0026per_page=100","prev":"https://api.digitalocean.com/v2/apps?page=1\u0026per_page=100"}}}"#;
+        let deserialized_data: ListAppsResponse = serde_json::from_str(json_data).unwrap();
+        let expected_result = ListAppsResponse {
+            apps: vec![]
         };
 
         assert_eq!(deserialized_data, expected_result)

--- a/src/client/key_manager.rs
+++ b/src/client/key_manager.rs
@@ -44,7 +44,7 @@ fn create_key_limit(time: DateTime<Utc>) -> KeyLimit {
     KeyLimit::new(
         [
             (250, Duration::minutes(1)),
-            (2000, Duration::hours(1))
+            (5000, Duration::hours(1))
         ],
         time,
     )

--- a/src/client/key_manager.rs
+++ b/src/client/key_manager.rs
@@ -68,11 +68,14 @@ pub enum KeyType {
     Default,
     Droplets,
     Apps,
-    Bandwidth,
-    Cpu,
-    FileSystem,
-    Memory,
-    Load,
+    DropletBandwidth,
+    DropletCpu,
+    DropletFileSystem,
+    DropletMemory,
+    DropletLoad,
+    AppCpuPercentage,
+    AppMemoryPercentage,
+    AppRestartCount,
 }
 
 impl KeyType {
@@ -81,11 +84,14 @@ impl KeyType {
             KeyType::Default => "default",
             KeyType::Apps => "apps",
             KeyType::Droplets => "droplets",
-            KeyType::Bandwidth => "bandwidth",
-            KeyType::Cpu => "cpu",
-            KeyType::FileSystem => "file_system",
-            KeyType::Memory => "memory",
-            KeyType::Load => "load",
+            KeyType::DropletBandwidth => "bandwidth",
+            KeyType::DropletCpu => "cpu",
+            KeyType::DropletFileSystem => "file_system",
+            KeyType::DropletMemory => "memory",
+            KeyType::DropletLoad => "load",
+            KeyType::AppCpuPercentage => "app_cpu_percentage",
+            KeyType::AppMemoryPercentage => "app_memory_percentage",
+            KeyType::AppRestartCount => "app_restart_count",
         }
     }
 }
@@ -100,32 +106,50 @@ impl KeyManagerState {
         keys.insert(KeyType::Apps, configs.apps.keys.clone());
         if let Some(bandwidth) = configs.droplet_metrics.bandwidth.as_ref() {
             keys.insert(
-                KeyType::Bandwidth,
+                KeyType::DropletBandwidth,
                 bandwidth.keys.clone(),
             );
         }
         if let Some(cpu) = configs.droplet_metrics.cpu.as_ref() {
             keys.insert(
-                KeyType::Cpu,
+                KeyType::DropletCpu,
                 cpu.keys.clone(),
             );
         }
         if let Some(filesystem) = configs.droplet_metrics.filesystem.as_ref() {
             keys.insert(
-                KeyType::FileSystem,
+                KeyType::DropletFileSystem,
                 filesystem.keys.clone(),
             );
         }
         if let Some(memory) = configs.droplet_metrics.memory.as_ref() {
             keys.insert(
-                KeyType::Memory,
+                KeyType::DropletMemory,
                 memory.keys.clone(),
             );
         }
         if let Some(load) = configs.droplet_metrics.load.as_ref() {
             keys.insert(
-                KeyType::Load,
+                KeyType::DropletLoad,
                 load.keys.clone(),
+            );
+        }
+        if let Some(app_cpu_percentage) = configs.app_metrics.cpu_percentage.as_ref() {
+            keys.insert(
+                KeyType::AppCpuPercentage,
+                app_cpu_percentage.keys.clone(),
+            );
+        }
+        if let Some(app_memory_percentage) = configs.app_metrics.memory_percentage.as_ref() {
+            keys.insert(
+                KeyType::AppMemoryPercentage,
+                app_memory_percentage.keys.clone(),
+            );
+        }
+        if let Some(app_restart_count) = configs.app_metrics.restart_count.as_ref() {
+            keys.insert(
+                KeyType::AppRestartCount,
+                app_restart_count.keys.clone(),
             );
         }
 
@@ -306,6 +330,10 @@ mod key_manager {
         configs.droplet_metrics.filesystem = Some(Default::default());
         configs.droplet_metrics.bandwidth = Some(Default::default());
 
+        configs.app_metrics.cpu_percentage = Some(Default::default());
+        configs.app_metrics.memory_percentage = Some(Default::default());
+        configs.app_metrics.restart_count = Some(Default::default());
+
         configs.default_keys = vec!["default".into()];
 
         configs.droplet_metrics.memory.as_mut().unwrap().keys = vec!["memory".into()];
@@ -315,22 +343,36 @@ mod key_manager {
         configs.droplet_metrics.bandwidth.as_mut().unwrap().keys = vec!["bandwidth".into()];
         configs.droplets.keys = vec!["droplets".into()];
 
+        configs.app_metrics.cpu_percentage.as_mut().unwrap().keys = vec!["app_cpu_percentage".into()];
+        configs.app_metrics.memory_percentage.as_mut().unwrap().keys = vec!["app_memory_percentage".into()];
+        configs.app_metrics.restart_count.as_mut().unwrap().keys = vec!["app_restart_count".into()];
+        configs.apps.keys = vec!["apps".into()];
+
         let manager = KeyManagerImpl::new(configs, Registry::new()).unwrap();
 
-        let key = manager.acquire_key(KeyType::Memory).unwrap();
+        let key = manager.acquire_key(KeyType::DropletMemory).unwrap();
         assert_eq!(key, "memory".to_string());
-        let key = manager.acquire_key(KeyType::Cpu).unwrap();
+        let key = manager.acquire_key(KeyType::DropletCpu).unwrap();
         assert_eq!(key, "cpu".to_string());
-        let key = manager.acquire_key(KeyType::Load).unwrap();
+        let key = manager.acquire_key(KeyType::DropletLoad).unwrap();
         assert_eq!(key, "load".to_string());
-        let key = manager.acquire_key(KeyType::FileSystem).unwrap();
+        let key = manager.acquire_key(KeyType::DropletFileSystem).unwrap();
         assert_eq!(key, "filesystem".to_string());
-        let key = manager.acquire_key(KeyType::Bandwidth).unwrap();
+        let key = manager.acquire_key(KeyType::DropletBandwidth).unwrap();
         assert_eq!(key, "bandwidth".to_string());
         let key = manager.acquire_key(KeyType::Default).unwrap();
         assert_eq!(key, "default".to_string());
         let key = manager.acquire_key(KeyType::Droplets).unwrap();
         assert_eq!(key, "droplets".to_string());
+
+        let key = manager.acquire_key(KeyType::AppCpuPercentage).unwrap();
+        assert_eq!(key, "app_cpu_percentage".to_string());
+        let key = manager.acquire_key(KeyType::AppMemoryPercentage).unwrap();
+        assert_eq!(key, "app_memory_percentage".to_string());
+        let key = manager.acquire_key(KeyType::AppRestartCount).unwrap();
+        assert_eq!(key, "app_restart_count".to_string());
+        let key = manager.acquire_key(KeyType::Apps).unwrap();
+        assert_eq!(key, "apps".to_string());
     }
 
     #[test]
@@ -344,10 +386,10 @@ mod key_manager {
         let manager = KeyManagerImpl::new(configs, Registry::new()).unwrap();
 
         for _ in 0..250 {
-            manager.acquire_key(KeyType::Memory).unwrap();
+            manager.acquire_key(KeyType::DropletMemory).unwrap();
         }
 
-        let key = manager.acquire_key(KeyType::Memory).unwrap();
+        let key = manager.acquire_key(KeyType::DropletMemory).unwrap();
         assert_eq!(key, "default".to_string());
     }
 
@@ -359,7 +401,7 @@ mod key_manager {
 
         let manager = KeyManagerImpl::new(configs, Registry::new()).unwrap();
 
-        let key = manager.acquire_key(KeyType::Memory).unwrap();
+        let key = manager.acquire_key(KeyType::DropletMemory).unwrap();
         assert_eq!(key, "default".to_string());
     }
 }

--- a/src/config/config_model.rs
+++ b/src/config/config_model.rs
@@ -11,7 +11,9 @@ pub struct AppSettings {
     #[serde(default)]
     pub droplets: DropletSettings,
     #[serde(default)]
-    pub metrics: MetricsConfig,
+    pub apps: AppPlatformSettings,
+    #[serde(default)]
+    pub droplet_metrics: MetricsConfig,
     #[serde(default)]
     pub exporter_metrics: ExporterMetricsConfigs,
     #[serde(default)]
@@ -132,6 +134,20 @@ pub struct DropletSettings {
     #[serde(default)]
     pub keys: Vec<Key>,
     #[serde(default = "default_droplets_url")]
+    pub url: String,
+    #[serde(default = "duration_1_hour")]
+    #[serde(with = "humantime_serde")]
+    pub interval: std::time::Duration,
+    #[serde(default)]
+    pub metrics: Vec<DropletMetricsTypes>,
+}
+
+#[derive(Deserialize, Clone, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct AppPlatformSettings {
+    #[serde(default)]
+    pub keys: Vec<Key>,
+    #[serde(default = "default_apps_url")]
     pub url: String,
     #[serde(default = "duration_1_hour")]
     #[serde(with = "humantime_serde")]
@@ -288,6 +304,10 @@ fn default_base_url() -> String {
 
 fn default_droplets_url() -> String {
     "https://api.digitalocean.com/v2/droplets".into()
+}
+
+fn default_apps_url() -> String {
+    "https://api.digitalocean.com/v2/apps".into()
 }
 
 fn default_true() -> bool {

--- a/src/config/config_model.rs
+++ b/src/config/config_model.rs
@@ -13,7 +13,9 @@ pub struct AppSettings {
     #[serde(default)]
     pub apps: AppPlatformSettings,
     #[serde(default)]
-    pub droplet_metrics: MetricsConfig,
+    pub droplet_metrics: DropletMetricsConfig,
+    #[serde(default)]
+    pub app_metrics: AppMetricsConfig,
     #[serde(default)]
     pub exporter_metrics: ExporterMetricsConfigs,
     #[serde(default)]
@@ -91,8 +93,8 @@ fn default_ssl_key() -> String {
 
 #[derive(Deserialize, Clone, Default)]
 #[serde(rename_all = "kebab-case")]
-pub struct MetricsConfig {
-    #[serde(default = "default_base_url")]
+pub struct DropletMetricsConfig {
+    #[serde(default = "default_droplet_metrics_base_url")]
     pub base_url: String,
 
     pub bandwidth: Option<BandwidthSettings>,
@@ -100,6 +102,17 @@ pub struct MetricsConfig {
     pub filesystem: Option<FilesystemSettings>,
     pub memory: Option<MemorySettings>,
     pub load: Option<LoadSettings>,
+}
+
+#[derive(Deserialize, Clone, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct AppMetricsConfig {
+    #[serde(default = "default_app_metrics_base_url")]
+    pub base_url: String,
+
+    pub cpu_percentage: Option<AppCpuPercentageSettings>,
+    pub memory_percentage: Option<AppMemoryPercentageSettings>,
+    pub restart_count: Option<AppRestartCountSettings>,
 }
 
 #[derive(Deserialize, Clone, Default)]
@@ -153,7 +166,7 @@ pub struct AppPlatformSettings {
     #[serde(with = "humantime_serde")]
     pub interval: std::time::Duration,
     #[serde(default)]
-    pub metrics: Vec<DropletMetricsTypes>,
+    pub metrics: Vec<AppMetricsTypes>,
 }
 
 #[derive(Deserialize, Clone, PartialEq, Eq)]
@@ -166,6 +179,12 @@ pub enum DropletMetricsTypes {
     Disk,
     #[serde(rename = "status")]
     Status,
+}
+
+#[derive(Deserialize, Clone, PartialEq, Eq)]
+pub enum AppMetricsTypes {
+    #[serde(rename = "active_deployment_phase")]
+    ActiveDeploymentPhase,
 }
 
 #[derive(Deserialize, Clone, Default)]
@@ -278,6 +297,42 @@ pub enum LoadTypes {
     Load15,
 }
 
+#[derive(Deserialize, Clone, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct AppCpuPercentageSettings {
+    #[serde(default)]
+    pub keys: Vec<String>,
+    #[serde(default = "duration_60_seconds")]
+    #[serde(with = "humantime_serde")]
+    pub interval: std::time::Duration,
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+}
+
+#[derive(Deserialize, Clone, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct AppMemoryPercentageSettings {
+    #[serde(default)]
+    pub keys: Vec<String>,
+    #[serde(default = "duration_60_seconds")]
+    #[serde(with = "humantime_serde")]
+    pub interval: std::time::Duration,
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+}
+
+#[derive(Deserialize, Clone, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct AppRestartCountSettings {
+    #[serde(default)]
+    pub keys: Vec<String>,
+    #[serde(default = "duration_60_seconds")]
+    #[serde(with = "humantime_serde")]
+    pub interval: std::time::Duration,
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+}
+
 fn duration_1_hour() -> std::time::Duration {
     std::time::Duration::from_secs(60 * 60)
 }
@@ -298,8 +353,12 @@ fn duration_120_seconds() -> std::time::Duration {
     std::time::Duration::from_secs(120)
 }
 
-fn default_base_url() -> String {
+fn default_droplet_metrics_base_url() -> String {
     "https://api.digitalocean.com/v2/monitoring/metrics/droplet".into()
+}
+
+fn default_app_metrics_base_url() -> String {
+    "https://api.digitalocean.com/v2/monitoring/metrics/apps".into()
 }
 
 fn default_droplets_url() -> String {

--- a/src/config/config_model.rs
+++ b/src/config/config_model.rs
@@ -12,7 +12,7 @@ pub struct AppSettings {
     pub droplets: DropletSettings,
     #[serde(default)]
     pub apps: AppPlatformSettings,
-    #[serde(default)]
+    #[serde(default, alias = "metrics")]
     pub droplet_metrics: DropletMetricsConfig,
     #[serde(default)]
     pub app_metrics: AppMetricsConfig,

--- a/src/metrics/app_metrics_loader.rs
+++ b/src/metrics/app_metrics_loader.rs
@@ -1,0 +1,204 @@
+use std::sync::Arc;
+use async_trait::async_trait;
+use chrono::{DateTime, Duration, Utc};
+use prometheus::Opts;
+use crate::client::do_client::DigitalOceanClient;
+use crate::client::do_json_protocol::{AppDataResponse, AppMetricMetaInfo, AppMetricsResponse};
+use crate::config::config_model::AppSettings;
+use crate::metrics::app_store::AppStore;
+use crate::metrics::utils;
+
+#[async_trait]
+pub trait AppMetricsService: Send + Sync {
+    async fn load_cpu_percentage(&self) -> anyhow::Result<()>;
+    async fn load_memory_percentage(&self) -> anyhow::Result<()>;
+    async fn load_restart_count(&self, interval_start: DateTime<Utc>, interval_end: DateTime<Utc>) -> anyhow::Result<()>;
+}
+
+
+#[derive(Clone)]
+pub struct AppMetricsServiceImpl {
+    client: Arc<dyn DigitalOceanClient>,
+    app_store: Arc<dyn AppStore>,
+    // There are no valid per metric settings yet.
+    configs: &'static AppSettings,
+    metrics: LoaderAppMetrics,
+}
+
+impl AppMetricsServiceImpl {
+    pub fn new(client: Arc<dyn DigitalOceanClient>,
+               app_store: Arc<dyn AppStore>,
+               configs: &'static AppSettings,
+               registry: prometheus::Registry) -> anyhow::Result<Self> {
+        let result = Self {
+            client,
+            app_store,
+            configs,
+            metrics: LoaderAppMetrics::new(registry)?,
+        };
+        Ok(result)
+    }
+}
+
+#[derive(Clone)]
+struct LoaderAppMetrics {
+    app_cpu_percentage: prometheus::GaugeVec,
+    app_memory_percentage: prometheus::GaugeVec,
+    app_restart_count: prometheus::CounterVec,
+}
+
+impl LoaderAppMetrics {
+    fn new(registry: prometheus::Registry) -> anyhow::Result<Self> {
+        let app_cpu_percentage = prometheus::GaugeVec::new(
+            Opts::new("droxporter_app_cpu_percentage", "App CPU %"),
+            &["app", "app_component", "app_component_instance"],
+        )?;
+        let app_memory_percentage = prometheus::GaugeVec::new(
+            Opts::new("droxporter_app_memory_percentage", "App Memory %"),
+            &["app", "app_component", "app_component_instance"],
+        )?;
+        let app_restart_count = prometheus::CounterVec::new(
+            Opts::new("droxporter_app_restart_count", "App restart count"),
+            &["app", "app_component", "app_component_instance"],
+        )?;
+        registry.register(Box::new(app_cpu_percentage.clone()))?;
+        registry.register(Box::new(app_memory_percentage.clone()))?;
+        registry.register(Box::new(app_restart_count.clone()))?;
+        let result = Self {
+            app_cpu_percentage,
+            app_memory_percentage,
+            app_restart_count,
+        };
+        Ok(result)
+    }
+}
+
+fn extract_app_meta_with_last_values(response: AppDataResponse) -> Vec<(AppMetricMetaInfo, f64)> {
+    response.data.result.into_iter()
+        .map(|x| {
+            let last_point = last_point_for_app_metrics(&x);
+            let info = x.metric;
+            (info, last_point)
+        }).collect()
+}
+
+fn extract_app_meta_with_sum_of_values(response: AppDataResponse) -> Vec<(AppMetricMetaInfo, f64)> {
+    response.data.result.into_iter()
+        .map(|x| {
+            let sum = sum_for_app_metrics(&x);
+            let info = x.metric;
+            (info, sum)
+        }).collect()
+}
+
+fn last_point_for_app_metrics(metrics: &AppMetricsResponse) -> f64 {
+    metrics.values.iter()
+        .max_by_key(|x| x.timestamp)
+        .and_then(|x| x.value.parse::<f64>().ok())
+        .unwrap_or(0f64)
+}
+
+fn sum_for_app_metrics(metrics: &AppMetricsResponse) -> f64 {
+    metrics.values.iter()
+        .map(|x| x.value.parse::<f64>().unwrap_or(0f64))
+        .sum()
+}
+
+fn metrics_read_interval() -> Duration {
+    // It seems that DO has a 10..15 second interval between points, so I think an interval of 1 minute is reasonable.
+    Duration::minutes(1)
+}
+
+// a lot of boilerplate. but I don't think it would be changing too often
+#[async_trait]
+impl AppMetricsService for AppMetricsServiceImpl {
+    async fn load_cpu_percentage(&self) -> anyhow::Result<()> {
+        let interval_end = Utc::now();
+        let interval_start = interval_end - metrics_read_interval();
+
+        for app in self.app_store.list_apps().iter() {
+            let res = self.client
+                .get_app_cpu_percentage(
+                    app.id.clone(),
+                    interval_start,
+                    interval_end
+                ).await?;
+            for (meta, value) in extract_app_meta_with_last_values(res) {
+                self.metrics.app_cpu_percentage
+                .with_label_values(&[
+                        &app.name.as_str(),
+                        &meta.app_component.as_str(),
+                        &meta.app_component_instance.as_str(),
+                    ]).set(value);
+            }
+        }
+
+        let apps = self.app_store.list_apps();
+        let apps_names: ahash::HashSet<_> = apps
+            .iter()
+            .map(|x| x.name.as_str())
+            .collect();
+        utils::remove_old_apps_for_gauge_metric(&self.metrics.app_cpu_percentage, &apps_names);
+
+        Ok(())
+    }
+
+    async fn load_memory_percentage(&self) -> anyhow::Result<()> {
+        let interval_end = Utc::now();
+        let interval_start = interval_end - metrics_read_interval();
+
+        for app in self.app_store.list_apps().iter() {
+            let res = self.client
+                .get_app_memory_percentage(
+                    app.id.clone(),
+                    interval_start,
+                    interval_end
+                ).await?;
+            for (meta, value) in extract_app_meta_with_last_values(res) {
+                self.metrics.app_memory_percentage
+                .with_label_values(&[
+                        &app.name.as_str(),
+                        &meta.app_component.as_str(),
+                        &meta.app_component_instance.as_str(),
+                    ]).set(value);
+            }
+        }
+
+        let apps = self.app_store.list_apps();
+        let apps_names: ahash::HashSet<_> = apps
+            .iter()
+            .map(|x| x.name.as_str())
+            .collect();
+        utils::remove_old_apps_for_gauge_metric(&self.metrics.app_memory_percentage, &apps_names);
+
+        Ok(())
+    }
+
+    async fn load_restart_count(&self, interval_start: DateTime<Utc>, interval_end: DateTime<Utc>) -> anyhow::Result<()> {
+        for app in self.app_store.list_apps().iter() {
+            let res = self.client
+                .get_app_restart_count(
+                    app.id.clone(),
+                    interval_start,
+                    interval_end
+                ).await?;
+            for (meta, value) in extract_app_meta_with_sum_of_values(res) {
+                self.metrics.app_restart_count
+                .with_label_values(&[
+                        &app.name.as_str(),
+                        &meta.app_component.as_str(),
+                        &meta.app_component_instance.as_str(),
+                    ]).inc_by(value);
+            }
+        }
+
+        let apps = self.app_store.list_apps();
+        let apps_names: ahash::HashSet<_> = apps
+            .iter()
+            .map(|x| x.name.as_str())
+            .collect();
+        utils::remove_old_apps_for_counter_metric(&self.metrics.app_restart_count, &apps_names);
+
+        Ok(())
+    }
+}

--- a/src/metrics/app_store.rs
+++ b/src/metrics/app_store.rs
@@ -1,0 +1,167 @@
+use std::sync::Arc;
+use ahash::{HashSet};
+use async_trait::async_trait;
+use parking_lot::{RwLock};
+use prometheus::Opts;
+use crate::client::do_client::DigitalOceanClient;
+use crate::client::do_json_protocol::AppResponse;
+use crate::config::config_model::{AppSettings};
+
+#[async_trait]
+pub trait AppStore: Send + Sync {
+    async fn load_apps(&self) -> anyhow::Result<()>;
+
+    fn record_app_metrics(&self);
+
+    fn list_apps(&self) -> Vec<BasicAppInfo>;
+}
+
+#[derive(Clone)]
+pub struct BasicAppInfo {
+    pub id: String,
+    pub name: String,
+}
+
+impl From<AppResponse> for BasicAppInfo {
+    fn from(value: AppResponse) -> Self {
+        Self {
+            id: value.id,
+            name: value.spec.name,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct AppStoreImpl {
+    store: Arc<RwLock<Vec<BasicAppInfo>>>,
+    client: Arc<dyn DigitalOceanClient>,
+    configs: &'static AppSettings,
+    metrics: AppMetrics,
+}
+
+impl AppStoreImpl {
+    pub fn new(client: Arc<dyn DigitalOceanClient>,
+               configs: &'static AppSettings,
+               registry: prometheus::Registry) -> anyhow::Result<Self> {
+        let result = Self {
+            store: Arc::new(RwLock::new(vec![])),
+            client,
+            configs,
+            metrics: AppMetrics::new(registry)?,
+        };
+        Ok(result)
+    }
+}
+
+
+#[derive(Clone)]
+struct AppMetrics {
+    up_gauge: prometheus::GaugeVec,
+}
+
+impl AppMetrics {
+    fn new(registry: prometheus::Registry) -> anyhow::Result<Self> {
+        let up_gauge = prometheus::GaugeVec::new(
+            Opts::new("droxporter_app_up", "Constant of 1 (DEBUG)"),
+            &["app"],
+        )?;
+
+        registry.register(Box::new(up_gauge.clone()))?;
+
+        let result = Self {
+            up_gauge,
+        };
+        Ok(result)
+    }
+}
+
+
+impl AppStoreImpl {
+    fn save_apps(&self,
+                 apps: Vec<BasicAppInfo>) {
+        *self.store.write() = apps;
+    }
+}
+
+
+#[async_trait]
+impl AppStore for AppStoreImpl {
+    async fn load_apps(&self) -> anyhow::Result<()> {
+        let mut result: Vec<BasicAppInfo> = Vec::new();
+        let mut fetch_next = true;
+        let mut page = 1u64;
+        let per_page: u64 = 100u64;
+        while fetch_next {
+            let loaded = self.client.list_apps(per_page, page).await?;
+            fetch_next = !loaded.apps.is_empty();
+            result.extend(loaded.apps.into_iter().map(BasicAppInfo::from));
+            page += 1;
+        }
+        self.save_apps(result);
+        Ok(())
+    }
+
+    fn record_app_metrics(&self) {
+        // let enabled_memory = self.configs.droplets.metrics.contains(&DropletMetricsTypes::Memory);
+        // let enabled_vcpu = self.configs.droplets.metrics.contains(&DropletMetricsTypes::VCpu);
+        // let enabled_disc = self.configs.droplets.metrics.contains(&DropletMetricsTypes::Disk);
+        // let enabled_status = self.configs.droplets.metrics.contains(&DropletMetricsTypes::Status);
+
+        for app in self.store.read().iter() {
+            let name = &app.name;
+
+            use std::collections::HashMap;
+            
+            let mut labels = HashMap::new();
+            labels.insert("app", name.as_ref());
+            
+            self.metrics.up_gauge
+                .with(&labels)
+                .set(1.0 as f64);
+            // if enabled_memory {
+            //     self.metrics.memory_gauge
+            //         .with(&std::collections::HashMap::from([
+            //             ("droplet", name.as_ref())
+            //         ])).set(app.memory as f64);
+            // }
+
+            // if enabled_vcpu {
+            //     self.metrics.vcpu_gauge
+            //         .with(&std::collections::HashMap::from([
+            //             ("droplet", name.as_ref())
+            //         ])).set(app.vcpus as f64);
+            // }
+
+            // if enabled_disc {
+            //     self.metrics.disk_gauge
+            //         .with(&std::collections::HashMap::from([
+            //             ("droplet", name.as_ref())
+            //         ])).set(app.disk as f64);
+            // }
+
+            // if enabled_status {
+            //     self.metrics.status_gauge
+            //         .with(&std::collections::HashMap::from([
+            //             ("droplet", name.as_ref()),
+            //             ("status", app.status.as_ref()),
+            //         ])).set(1 as f64);
+            // }
+        }
+        let lock = self.store.read();
+        let apps: HashSet<_> = {
+            lock.iter().map(|x| x.name.as_str()).collect()
+        };
+
+        // // to prevent phantom droplets
+        // utils::remove_old_droplets(&self.metrics.memory_gauge, &droplets);
+        // utils::remove_old_droplets(&self.metrics.vcpu_gauge, &droplets);
+        // utils::remove_old_droplets(&self.metrics.disk_gauge, &droplets);
+        // utils::remove_old_droplets(&self.metrics.status_gauge, &droplets);
+    }
+
+    fn list_apps(&self) -> Vec<BasicAppInfo> {
+        self.store.read().clone()
+    }
+}
+
+

--- a/src/metrics/app_store.rs
+++ b/src/metrics/app_store.rs
@@ -99,7 +99,7 @@ impl AppStore for AppStoreImpl {
         let per_page: u64 = 100u64;
         while fetch_next {
             let loaded = self.client.list_apps(per_page, page).await?;
-            fetch_next = !loaded.apps.is_empty();
+            fetch_next = loaded.links.pages.next.is_some();
             result.extend(loaded.apps.into_iter().map(BasicAppInfo::from));
             page += 1;
         }

--- a/src/metrics/droplet_metrics_loader.rs
+++ b/src/metrics/droplet_metrics_loader.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use chrono::{Duration, Utc};
 use prometheus::Opts;
 use crate::client::do_client::{ClientLoadType, DigitalOceanClient, FileSystemRequest, MemoryRequest, NetworkDirection, NetworkInterface};
-use crate::client::do_json_protocol::{DataResponse, MetricMetaInfo, MetricsResponse};
+use crate::client::do_json_protocol::{DropletDataResponse, DropletMetricMetaInfo, DropletMetricsResponse};
 use crate::config::config_model::{AppSettings, BandwidthType, FilesystemTypes, LoadTypes, MemoryTypes};
 use crate::metrics::droplet_store::DropletStore;
 use crate::metrics::utils;
@@ -23,7 +23,7 @@ pub struct DropletMetricsServiceImpl {
     client: Arc<dyn DigitalOceanClient>,
     droplet_store: Arc<dyn DropletStore>,
     configs: &'static AppSettings,
-    metrics: LoaderMetrics,
+    metrics: LoaderDropletMetrics,
 }
 
 impl DropletMetricsServiceImpl {
@@ -35,14 +35,14 @@ impl DropletMetricsServiceImpl {
             client,
             droplet_store,
             configs,
-            metrics: LoaderMetrics::new(registry)?,
+            metrics: LoaderDropletMetrics::new(registry)?,
         };
         Ok(result)
     }
 }
 
 #[derive(Clone)]
-struct LoaderMetrics {
+struct LoaderDropletMetrics {
     droplet_bandwidth: prometheus::GaugeVec,
     droplet_cpu: prometheus::GaugeVec,
     droplet_filesystem: prometheus::GaugeVec,
@@ -50,7 +50,7 @@ struct LoaderMetrics {
     droplet_load: prometheus::GaugeVec,
 }
 
-impl LoaderMetrics {
+impl LoaderDropletMetrics {
     fn new(registry: prometheus::Registry) -> anyhow::Result<Self> {
         let droplet_bandwidth = prometheus::GaugeVec::new(
             Opts::new("droxporter_droplet_bandwidth", "Bandwidth of droplet"),
@@ -97,7 +97,7 @@ macro_rules! unwrap_or_return_ok {
     }
 }
 
-fn extract_last_value(response: DataResponse) -> f64 {
+fn extract_last_value(response: DropletDataResponse) -> f64 {
     response.data.result.iter()
         .flat_map(|x| x.values.iter())
         .max_by_key(|x| x.timestamp)
@@ -105,7 +105,7 @@ fn extract_last_value(response: DataResponse) -> f64 {
         .unwrap_or(0f64)
 }
 
-fn extract_meta_with_last_values(response: DataResponse) -> Vec<(MetricMetaInfo, f64)> {
+fn extract_meta_with_last_values(response: DropletDataResponse) -> Vec<(DropletMetricMetaInfo, f64)> {
     response.data.result.into_iter()
         .map(|x| {
             let last_point = last_point_for_metric(&x);
@@ -114,7 +114,7 @@ fn extract_meta_with_last_values(response: DataResponse) -> Vec<(MetricMetaInfo,
         }).collect()
 }
 
-fn last_point_for_metric(metrics: &MetricsResponse) -> f64 {
+fn last_point_for_metric(metrics: &DropletMetricsResponse) -> f64 {
     metrics.values.iter()
         .max_by_key(|x| x.timestamp)
         .and_then(|x| x.value.parse::<f64>().ok())
@@ -154,7 +154,7 @@ impl DropletMetricsService for DropletMetricsServiceImpl {
         for droplet in droplets.iter() {
             for (interface, dir) in &metric_types {
                 let res = self.client
-                    .get_bandwidth(
+                    .get_droplet_bandwidth(
                         droplet.id,
                         *interface,
                         *dir,
@@ -196,7 +196,7 @@ impl DropletMetricsService for DropletMetricsServiceImpl {
 
         for droplet in self.droplet_store.list_droplets().iter() {
             let res = self.client
-                .get_cpu(
+                .get_droplet_cpu(
                     droplet.id,
                     interval_start,
                     interval_end
@@ -240,7 +240,7 @@ impl DropletMetricsService for DropletMetricsServiceImpl {
         for droplet in self.droplet_store.list_droplets().iter() {
             for metrics_type in &filesystem_types {
                 let res = self.client
-                    .get_file_system(
+                    .get_droplet_file_system(
                         droplet.id,
                         *metrics_type,
                         interval_start,
@@ -355,7 +355,7 @@ impl DropletMetricsService for DropletMetricsServiceImpl {
         for droplet in self.droplet_store.list_droplets().iter() {
             for load_type in &load_types {
                 let res = self.client
-                    .get_load(
+                    .get_droplet_load(
                         droplet.id,
                         *load_type,
                         interval_start,

--- a/src/metrics/droplet_metrics_loader.rs
+++ b/src/metrics/droplet_metrics_loader.rs
@@ -130,7 +130,7 @@ fn metrics_read_interval() -> Duration {
 #[async_trait]
 impl DropletMetricsService for DropletMetricsServiceImpl {
     async fn load_bandwidth(&self) -> anyhow::Result<()> {
-        let bandwidth = unwrap_or_return_ok!(self.configs.metrics.bandwidth.as_ref());
+        let bandwidth = unwrap_or_return_ok!(self.configs.droplet_metrics.bandwidth.as_ref());
 
         let enable_private_in = bandwidth.types.contains(&BandwidthType::PrivateInbound);
         let enable_private_out = bandwidth.types.contains(&BandwidthType::PrivateOutbound);
@@ -222,7 +222,7 @@ impl DropletMetricsService for DropletMetricsServiceImpl {
     }
 
     async fn load_filesystem_metrics(&self) -> anyhow::Result<()> {
-        let filesystem = unwrap_or_return_ok!(self.configs.metrics.filesystem.as_ref());
+        let filesystem = unwrap_or_return_ok!(self.configs.droplet_metrics.filesystem.as_ref());
 
         let enable_free = filesystem.types.contains(&FilesystemTypes::Free);
         let enable_size = filesystem.types.contains(&FilesystemTypes::Size);
@@ -279,7 +279,7 @@ impl DropletMetricsService for DropletMetricsServiceImpl {
     }
 
     async fn load_memory_metrics(&self) -> anyhow::Result<()> {
-        let memory = unwrap_or_return_ok!(self.configs.metrics.memory.as_ref());
+        let memory = unwrap_or_return_ok!(self.configs.droplet_metrics.memory.as_ref());
 
         let enable_free = memory.types.contains(&MemoryTypes::Free);
         let enable_available = memory.types.contains(&MemoryTypes::Available);
@@ -335,7 +335,7 @@ impl DropletMetricsService for DropletMetricsServiceImpl {
     }
 
     async fn load_load_metrics(&self) -> anyhow::Result<()> {
-        let load = unwrap_or_return_ok!(self.configs.metrics.load.as_ref());
+        let load = unwrap_or_return_ok!(self.configs.droplet_metrics.load.as_ref());
 
         let enable_load1 = load.types.contains(&LoadTypes::Load1);
         let enable_load5 = load.types.contains(&LoadTypes::Load5);

--- a/src/metrics/droplet_store.rs
+++ b/src/metrics/droplet_store.rs
@@ -125,7 +125,7 @@ impl DropletStore for DropletStoreImpl {
         let per_page: u64 = 100u64;
         while fetch_next {
             let loaded = self.client.list_droplets(per_page, page).await?;
-            fetch_next = !loaded.droplets.is_empty();
+            fetch_next = loaded.links.pages.next.is_some();
             result.extend(loaded.droplets.into_iter().map(BasicDropletInfo::from));
             page += 1;
         }

--- a/src/metrics/jobs_scheduler.rs
+++ b/src/metrics/jobs_scheduler.rs
@@ -161,7 +161,7 @@ impl MetricsScheduler for MetricsSchedulerImpl {
                 info!("Bandwidth metrics are disabled");
                 return Ok(());
             }
-            info!("Staring bandwidth metrics loading loop");
+            info!("Starting bandwidth metrics loading loop");
 
             // timeout for initial load
             // looks ugly, but simple =)
@@ -190,7 +190,7 @@ impl MetricsScheduler for MetricsSchedulerImpl {
                 info!("Cpu metrics are disabled");
                 return Ok(());
             }
-            info!("Staring cpu metrics loading loop");
+            info!("Starting cpu metrics loading loop");
 
             // timeout for initial load
             // looks ugly, but simple =)
@@ -219,7 +219,7 @@ impl MetricsScheduler for MetricsSchedulerImpl {
                 info!("Filesystem metrics are disabled");
                 return Ok(());
             }
-            info!("Staring filesystem metrics loading loop");
+            info!("Starting filesystem metrics loading loop");
 
             // timeout for initial load
             // looks ugly, but simple =)
@@ -248,7 +248,7 @@ impl MetricsScheduler for MetricsSchedulerImpl {
                 info!("Memory metrics are disabled");
                 return Ok(());
             }
-            info!("Staring memory metrics loading loop");
+            info!("Starting memory metrics loading loop");
 
             // timeout for initial load
             // looks ugly, but simple =)
@@ -277,7 +277,7 @@ impl MetricsScheduler for MetricsSchedulerImpl {
                 info!("Load metrics are disabled");
                 return Ok(());
             }
-            info!("Staring load metrics loading loop");
+            info!("Starting load metrics loading loop");
 
 
             // timeout for initial load
@@ -307,7 +307,7 @@ impl MetricsScheduler for MetricsSchedulerImpl {
             info!("Agent metrics are disabled");
             return Ok(());
         }
-        info!("Staring load agent metrics loop");
+        info!("Starting load agent metrics loop");
         // timeout for initial load
         // looks ugly, but simple =)
         let first_delay = Duration::from_secs(10).min(self.configs.exporter_metrics.interval);

--- a/src/metrics/jobs_scheduler.rs
+++ b/src/metrics/jobs_scheduler.rs
@@ -326,83 +326,83 @@ impl MetricsScheduler for MetricsSchedulerImpl {
     }
 
     async fn run_app_cpu_percentage_metrics_loading(&self) -> anyhow::Result<()> {
-        if let Some(cpu_percentage) = self.configs.app_metrics.cpu_percentage.as_ref() {
-            if !cpu_percentage.enabled {
-                info!("Apps cpu_percentage metrics are disabled");
+        if let Some(app_cpu_percentage) = self.configs.app_metrics.cpu_percentage.as_ref() {
+            if !app_cpu_percentage.enabled {
+                info!("Apps app_cpu_percentage metrics are disabled");
                 return Ok(());
             }
-            info!("Starting Apps cpu_percentage metrics loading loop");
+            info!("Starting Apps app_cpu_percentage metrics loading loop");
 
             // timeout for initial load
             // looks ugly, but simple =)
-            let first_delay = Duration::from_secs(10).min(cpu_percentage.interval);
+            let first_delay = Duration::from_secs(10).min(app_cpu_percentage.interval);
             let mut first = true;
             loop {
-                let timeout = if first { first_delay } else { cpu_percentage.interval };
+                let timeout = if first { first_delay } else { app_cpu_percentage.interval };
                 first = false;
                 tokio::time::sleep(timeout).await;
                 let start = Instant::now();
 
                 if let Err(e) = self.app_metrics_service.load_cpu_percentage().await {
-                    error!("Apps cpu_percentage metrics loading failed with err {e}");
-                    self.record_job_metrics("cpu_percentage", false, start);
+                    error!("Apps app_cpu_percentage metrics loading failed with err {e}");
+                    self.record_job_metrics("app_cpu_percentage", false, start);
                     continue;
                 }
-                self.record_job_metrics("cpu_percentage", true, start);
+                self.record_job_metrics("app_cpu_percentage", true, start);
             }
         }
         Ok(())
     }
 
     async fn run_app_memory_percentage_metrics_loading(&self) -> anyhow::Result<()> {
-        if let Some(memory_percentage) = self.configs.app_metrics.memory_percentage.as_ref() {
-            if !memory_percentage.enabled {
-                info!("Apps memory_percentage metrics are disabled");
+        if let Some(app_memory_percentage) = self.configs.app_metrics.memory_percentage.as_ref() {
+            if !app_memory_percentage.enabled {
+                info!("Apps app_memory_percentage metrics are disabled");
                 return Ok(());
             }
-            info!("Starting Apps memory_percentage metrics loading loop");
+            info!("Starting Apps app_memory_percentage metrics loading loop");
 
             // timeout for initial load
             // looks ugly, but simple =)
-            let first_delay = Duration::from_secs(10).min(memory_percentage.interval);
+            let first_delay = Duration::from_secs(10).min(app_memory_percentage.interval);
             let mut first = true;
             loop {
-                let timeout = if first { first_delay } else { memory_percentage.interval };
+                let timeout = if first { first_delay } else { app_memory_percentage.interval };
                 first = false;
                 tokio::time::sleep(timeout).await;
                 let start = Instant::now();
 
                 if let Err(e) = self.app_metrics_service.load_memory_percentage().await {
-                    error!("Apps memory_percentage metrics loading failed with err {e}");
-                    self.record_job_metrics("memory_percentage", false, start);
+                    error!("Apps app_memory_percentage metrics loading failed with err {e}");
+                    self.record_job_metrics("app_memory_percentage", false, start);
                     continue;
                 }
-                self.record_job_metrics("memory_percentage", true, start);
+                self.record_job_metrics("app_memory_percentage", true, start);
             }
         }
         Ok(())
     }
 
     async fn run_app_restart_count_metrics_loading(&self) -> anyhow::Result<()> {
-        if let Some(restart_count) = self.configs.app_metrics.restart_count.as_ref() {
-            if !restart_count.enabled {
-                info!("Apps restart_count metrics are disabled");
+        if let Some(app_restart_count) = self.configs.app_metrics.restart_count.as_ref() {
+            if !app_restart_count.enabled {
+                info!("Apps app_restart_count metrics are disabled");
                 return Ok(());
             }
-            info!("Starting Apps restart_count metrics loading loop");
+            info!("Starting Apps app_restart_count metrics loading loop");
 
             // timeout for initial load
             // looks ugly, but simple =)
-            let first_delay = Duration::from_secs(10).min(restart_count.interval);
+            let first_delay = Duration::from_secs(10).min(app_restart_count.interval);
             let mut first = true;
             let mut last_interval_end: Option<DateTime<Utc>> = None;
             loop {
-                let timeout = if first { first_delay } else { restart_count.interval };
+                let timeout = if first { first_delay } else { app_restart_count.interval };
                 first = false;
                 tokio::time::sleep(timeout).await;
                 let start = Instant::now();
 
-                // restart_count is a counter, so we keep track about which
+                // app_restart_count is a counter, so we keep track about which
                 // interval we have queried last time in order to not overlap.
                 let interval_end = Utc::now() - Duration::from_secs(1);
                 let interval_start = last_interval_end.unwrap_or(interval_end);
@@ -410,11 +410,11 @@ impl MetricsScheduler for MetricsSchedulerImpl {
                 last_interval_end = Some(interval_end + Duration::from_secs(1));
 
                 if let Err(e) = self.app_metrics_service.load_restart_count(interval_start, interval_end).await {
-                    error!("Apps restart_count metrics loading failed with err {e}");
-                    self.record_job_metrics("restart_count", false, start);
+                    error!("Apps app_restart_count metrics loading failed with err {e}");
+                    self.record_job_metrics("app_restart_count", false, start);
                     continue;
                 }
-                self.record_job_metrics("restart_count", true, start);
+                self.record_job_metrics("app_restart_count", true, start);
             }
         }
         Ok(())

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -1,5 +1,6 @@
 pub mod jobs_scheduler;
 pub mod droplet_store;
+pub mod app_store;
 pub mod droplet_metrics_loader;
 pub mod utils;
 pub mod agent_metrics;

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -2,5 +2,6 @@ pub mod jobs_scheduler;
 pub mod droplet_store;
 pub mod app_store;
 pub mod droplet_metrics_loader;
+pub mod app_metrics_loader;
 pub mod utils;
 pub mod agent_metrics;

--- a/src/metrics/utils.rs
+++ b/src/metrics/utils.rs
@@ -24,6 +24,52 @@ pub fn remove_old_droplets(gauge: &prometheus::GaugeVec,
     }
 }
 
+pub fn remove_old_apps_for_gauge_metric(gauge: &prometheus::GaugeVec,
+                                        valid_apps: &HashSet<&str>) {
+    let labels_to_delete: Vec<_> = gauge.collect()
+        .iter()
+        .flat_map(|m| m.get_metric().to_vec())
+        .filter(|m| {
+            m.get_label()
+                .iter()
+                .find(|label| label.get_name() == "app")
+                .iter()
+                .all(|label| !valid_apps.contains(label.get_value()))
+        }).collect();
+
+    for m in labels_to_delete {
+        let labels: std::collections::HashMap<_, _> = m.get_label()
+            .iter()
+            .map(|l| (l.get_name(), l.get_value()))
+            .collect();
+
+        let _ = gauge.remove(&labels);
+    }
+}
+
+pub fn remove_old_apps_for_counter_metric(counter: &prometheus::CounterVec,
+                                          valid_apps: &HashSet<&str>) {
+    let labels_to_delete: Vec<_> = counter.collect()
+        .iter()
+        .flat_map(|m| m.get_metric().to_vec())
+        .filter(|m| {
+            m.get_label()
+                .iter()
+                .find(|label| label.get_name() == "app")
+                .iter()
+                .all(|label| !valid_apps.contains(label.get_value()))
+        }).collect();
+
+    for m in labels_to_delete {
+        let labels: std::collections::HashMap<_, _> = m.get_label()
+            .iter()
+            .map(|l| (l.get_name(), l.get_value()))
+            .collect();
+
+        let _ = counter.remove(&labels);
+    }
+}
+
 // Personally, I prefer Summaries because they are more accurate, but in Rust I have no choice =(
 pub const DROXPORTER_DEFAULT_BUCKETS: &[f64; 16] = &[
     0.001, 0.004, 0.008, 0.016, 0.032, 0.064, 0.128, 0.256, 0.512, 1.024, 2.048, 8.192, 16.384, 32.768, 131.072, 262.144


### PR DESCRIPTION
Hi! Thanks for this wonderful project. It allowed us to get started quickly with integrating droplets metrics into Prometheus. However I also required the metrics data from Apps, so I figured the best approach would be to integrate scraping App metrics from the API using droxporter as well.

So here is a PR containing:
- Scraping API metrics in the same way as droplet metrics are scraped
- Allow configuration to decide which app metrics should be scraped

Notes on implementation:
- I mainly copied over the droplet related logic and made it work for apps, so there might be some code duplication which could have been written in a more [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) way, but I think the code is rather readable and easy to maintain this way
- There might be a backwards-incompatible change in the config as I have renamed `metrics:` to `droplet-metrics:` to be consistent in naming. Happy to discuss this what you prefer here (see [config.yaml](https://github.com/a14e/droxporter/pull/1/files#diff-5a7db8dbadaef1b1b5a8738ba70b5ffac82b8e243732154165911284e08aad4bR67))
- The Cargo.lock was updated while working on the repo - I haven't added new dependencies so this might have been not needed (I am not proficient in Rust, so sorry for any mishaps in that regard)

I am really keen to hear what you think of this extensions.